### PR TITLE
Develop

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,15 +1,12 @@
 {
-    "recommendations": [
-        "aliariff.vscode-erb-beautify",
-    ],
-    "files.associations": {
-        "*.html.erb": "erb"
-    },
     "[erb]": {
         "editor.defaultFormatter": "aliariff.vscode-erb-beautify",
         "editor.formatOnSave": true
     },
-    "vscode-erb-beautify.executePath": "path_to_htmlbeautifier",
+    "files.associations": {
+        "*.html.erb": "erb"
+    },
+
     "vscode-erb-beautify.customEnvVar": {
         "LC_ALL": "en_US.UTF-8"
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,15 @@ require 'open-uri'
 require 'nokogiri'
 require 'sanitize'
 
+class Net::HTTP
+  def initialize_new(address, port = nil)
+    initialize_old(address, port)
+    @read_timeout = 900 # timeoutを15分に変更
+  end
+  alias :initialize_old :initialize
+  alias :initialize :initialize_new
+end
+
 class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :validate_ipaddress

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -15,17 +15,6 @@
 <p> <strong>写真: </strong>
     <%= image_tag(@blog.image.url) if @blog.image.present? %>
 </p>
-<p> <strong>連続写真: </strong>
-    <% @blog.images.each do |image| %>
-    <%= image_tag image, class: "image" %>
-    <% end %>
-</p>
-<p> <strong>音楽: </strong>
-<% if @blog.file.present? %>
-    <audio src= "<%= "#{@blog.file}" %>" controls=""></audio>
-<% else %>
-<% end %>
-</p>
 <br />
 <p>
     <div class="video-player"> <strong>動画: </strong>


### PR DESCRIPTION
```markdown
NameError (undefined local variable or method 'exception' for an instance of Users::SessionsController)
Caused by: Net::ReadTimeout (Net::ReadTimeout with #<TCPSocket:(closed)>)

Information for: NameError (undefined local variable or method 'exception' for an instance of Users::SessionsController):

app/controllers/application_controller.rb:65:in 'ApplicationController#validate_justice'

Information for cause: Net::ReadTimeout (Net::ReadTimeout with #<TCPSocket:(closed)>):

app/controllers/application_controller.rb:37:in 'ApplicationController#validate_justice'
Started GET "/users/sign_in" for 127.0.0.1 at 2025-09-22 05:46:33 +0900
Processing by Users::SessionsController#new as HTML
Completed 500 Internal Server Error in 128079ms (ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 1990.3ms)



NameError (undefined local variable or method 'exception' for an instance of Users::SessionsController)
Caused by: Net::ReadTimeout (Net::ReadTimeout with #<TCPSocket:(closed)>)

Information for: NameError (undefined local variable or method 'exception' for an instance of Users::SessionsController):

app/controllers/application_controller.rb:65:in 'ApplicationController#validate_justice'

Information for cause: Net::ReadTimeout (Net::ReadTimeout with #<TCPSocket:(closed)>):

app/controllers/application_controller.rb:37:in 'ApplicationController#validate_justice'
- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2025-09-22 05:49:03 +0900 ===
```

※ タイムアウトエラーの対処、15分待機に変更。